### PR TITLE
fix(Work.vue): remove pointer-events-none from article element

### DIFF
--- a/src/components/Work.vue
+++ b/src/components/Work.vue
@@ -3,7 +3,6 @@
     :aria-label="'Project: ' + projectTitle"
     class="grid place-items-center shadow-md"
     :data-expanded="readMoreStatus"
-    :class="{ 'pointer-events-none': !readMoreStatus }"
   >
     <div class="max-w-sm w-full mx-2 rounded overflow-hidden shadow-lg bg-white flex flex-col">
       <img


### PR DESCRIPTION
The pointer-events-none class was preventing click events on the expand/collapse button when the card was collapsed. The component already handles collapsed state properly with v-show, opacity, and ARIA attributes, making the pointer-events-none class unnecessary and problematic.